### PR TITLE
GitHub Deprecating set-output command

### DIFF
--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -105,6 +105,6 @@ else
   fi
 fi
 
-echo "::set-output name=version::$TAG_VERSION"
-echo "::set-output name=name::$RELEASE_NAME"
-echo "::set-output name=body::$RELEASE_BODY"
+echo "version=$TAG_VERSION" >> "$GITHUB_ENV"
+echo "name=$RELEASE_NAME" >> "$GITHUB_ENV"
+echo "body=$RELEASE_BODY" >> "$GITHUB_ENV"

--- a/fetch_github_asset.sh
+++ b/fetch_github_asset.sh
@@ -105,6 +105,7 @@ else
   fi
 fi
 
-echo "version=$TAG_VERSION" >> "$GITHUB_ENV"
-echo "name=$RELEASE_NAME" >> "$GITHUB_ENV"
-echo "body=$RELEASE_BODY" >> "$GITHUB_ENV"
+echo "version=$TAG_VERSION" >> $GITHUB_OUTPUT
+echo "name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+RELEASE_BODY=$(echo $RELEASE_BODY | tr '\n' ' ')
+echo "body=$RELEASE_BODY" >> $GITHUB_OUTPUT


### PR DESCRIPTION
As per the official [blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#:~:text=Action%20and%20workflow%20authors%20who%20are%20using%20save%2Dstate%20or%20set%2Doutput%20via%20stdout%20should%20update%20to%20use%20the%20new%20environment%20files.) from GitHub, Action and workflow authors who are using save-state or set-output via stdout should update to use the new [environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).

Note: I handled the case of assigning a multiline string to the GITHUB_OUTPUT.  It is working as expected.